### PR TITLE
feat: add hamburger menu for mobile navigation

### DIFF
--- a/contributors/index.html
+++ b/contributors/index.html
@@ -56,6 +56,9 @@
         <a href="/contributors/">Contributors</a>
         <a href="https://blog.pumpkinmc.org/">Blog</a>
       </nav>
+      <button class="burger-btn" aria-label="Toggle menu" aria-expanded="false">
+        <i class="fa-solid fa-bars"></i>
+      </button>
       <div class="header-icons">
         <a
           href="https://github.com/Pumpkin-MC/Pumpkin"
@@ -82,6 +85,17 @@
       </div>
     </header>
     </div>
+    <script>
+      document.querySelector(".burger-btn").addEventListener("click", function () {
+        const header = document.querySelector("header");
+        const expanded = this.getAttribute("aria-expanded") === "true";
+        header.classList.toggle("nav-open");
+        this.setAttribute("aria-expanded", !expanded);
+        this.querySelector("i").className = expanded
+          ? "fa-solid fa-bars"
+          : "fa-solid fa-xmark";
+      });
+    </script>
 
     <!-- Google tag (gtag.js) -->
     <script

--- a/developers/index.html
+++ b/developers/index.html
@@ -56,6 +56,9 @@
         <a href="/contributors/">Contributors</a>
         <a href="https://blog.pumpkinmc.org/">Blog</a>
       </nav>
+      <button class="burger-btn" aria-label="Toggle menu" aria-expanded="false">
+        <i class="fa-solid fa-bars"></i>
+      </button>
       <div class="header-icons">
         <a
           href="https://github.com/Pumpkin-MC/Pumpkin"
@@ -82,6 +85,17 @@
       </div>
     </header>
     </div>
+    <script>
+      document.querySelector(".burger-btn").addEventListener("click", function () {
+        const header = document.querySelector("header");
+        const expanded = this.getAttribute("aria-expanded") === "true";
+        header.classList.toggle("nav-open");
+        this.setAttribute("aria-expanded", !expanded);
+        this.querySelector("i").className = expanded
+          ? "fa-solid fa-bars"
+          : "fa-solid fa-xmark";
+      });
+    </script>
 
     <!-- Google tag (gtag.js) -->
     <script

--- a/download/index.html
+++ b/download/index.html
@@ -56,6 +56,9 @@
         <a href="/contributors/">Contributors</a>
         <a href="https://blog.pumpkinmc.org/">Blog</a>
       </nav>
+      <button class="burger-btn" aria-label="Toggle menu" aria-expanded="false">
+        <i class="fa-solid fa-bars"></i>
+      </button>
       <div class="header-icons">
         <a
           href="https://github.com/Pumpkin-MC/Pumpkin"
@@ -82,6 +85,17 @@
       </div>
     </header>
     </div>
+    <script>
+      document.querySelector(".burger-btn").addEventListener("click", function () {
+        const header = document.querySelector("header");
+        const expanded = this.getAttribute("aria-expanded") === "true";
+        header.classList.toggle("nav-open");
+        this.setAttribute("aria-expanded", !expanded);
+        this.querySelector("i").className = expanded
+          ? "fa-solid fa-bars"
+          : "fa-solid fa-xmark";
+      });
+    </script>
 
     <!-- Google tag (gtag.js) -->
     <script

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
         <a href="/contributors/">Contributors</a>
         <a href="https://blog.pumpkinmc.org/">Blog</a>
       </nav>
+      <button class="burger-btn" aria-label="Toggle menu" aria-expanded="false">
+        <i class="fa-solid fa-bars"></i>
+      </button>
       <div class="header-icons">
         <a
           href="https://github.com/Pumpkin-MC/Pumpkin"
@@ -82,6 +85,17 @@
       </div>
     </header>
     </div>
+    <script>
+      document.querySelector(".burger-btn").addEventListener("click", function () {
+        const header = document.querySelector("header");
+        const expanded = this.getAttribute("aria-expanded") === "true";
+        header.classList.toggle("nav-open");
+        this.setAttribute("aria-expanded", !expanded);
+        this.querySelector("i").className = expanded
+          ? "fa-solid fa-bars"
+          : "fa-solid fa-xmark";
+      });
+    </script>
 
     <!-- Google tag (gtag.js) -->
     <script

--- a/style.css
+++ b/style.css
@@ -216,6 +216,30 @@ nav a:hover::after {
   box-shadow: 5px 5px 0 var(--pink);
 }
 
+/* Burger menu (hidden on desktop) */
+.burger-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 1.25rem;
+  border: 3px solid var(--text);
+  box-shadow: 3px 3px 0 var(--text);
+  cursor: pointer;
+  font-family: var(--font);
+  transition: all 0.1s ease;
+}
+
+.burger-btn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 5px 5px 0 var(--orange);
+  border-color: var(--orange);
+  color: var(--orange);
+}
+
 /* ==========================================
    Buttons
    ========================================== */
@@ -968,42 +992,63 @@ footer {
     height: 32px;
   }
 
-  .header-icons {
-    gap: 0.35rem;
-    flex-shrink: 0;
+  .burger-btn {
+    display: flex;
+    width: 38px;
+    height: 38px;
+    font-size: 1.1rem;
+    box-shadow: none;
+    margin-left: auto;
   }
 
   nav {
+    display: none;
     order: 3;
     width: 100%;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 0.25rem;
+    flex-direction: column;
+    gap: 0;
     box-sizing: border-box;
+    border-top: 2px solid var(--orange);
+    padding-top: 0.5rem;
   }
 
   nav a {
-    padding: 0.4rem 0.6rem;
-    font-size: 0.8rem;
+    padding: 0.75rem 0.5rem;
+    font-size: 0.95rem;
     white-space: nowrap;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   }
 
   nav a::after {
     display: none;
   }
 
+  .header-icons {
+    display: none;
+    order: 4;
+    width: 100%;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 0 0.25rem;
+  }
+
+  header.nav-open nav,
+  header.nav-open .header-icons {
+    display: flex;
+  }
+
   .download-btn {
-    height: 34px;
-    padding: 0 0.75rem;
-    font-size: 0.8rem;
+    height: 38px;
+    padding: 0 1rem;
+    font-size: 0.9rem;
     box-shadow: none;
   }
 
   .icon-btn,
   .sponsor-btn {
-    width: 34px;
-    height: 34px;
-    font-size: 1rem;
+    width: 38px;
+    height: 38px;
+    font-size: 1.1rem;
     box-shadow: none;
   }
 
@@ -1158,26 +1203,10 @@ footer {
     height: 26px;
   }
 
-  nav a {
-    padding: 0.3rem 0.4rem;
-    font-size: 0.7rem;
-  }
-
-  .header-icons {
-    gap: 0.2rem;
-  }
-
-  .download-btn {
-    height: 28px;
-    padding: 0 0.4rem;
-    font-size: 0.7rem;
-  }
-
-  .icon-btn,
-  .sponsor-btn {
-    width: 28px;
-    height: 28px;
-    font-size: 0.85rem;
+  .burger-btn {
+    width: 32px;
+    height: 32px;
+    font-size: 1rem;
   }
 
   .section-title {


### PR DESCRIPTION
## Summary
- Replace the wrapping nav layout on mobile (≤768px) with a hamburger menu button
- Tapping the burger toggles a vertical dropdown showing nav links and header icon buttons
- Icon swaps between bars/xmark on open/close, with `aria-expanded` for accessibility
- Burger button matches the existing design system (border, shadow, hover effects)
- Applied consistently across all 4 pages (index, download, contributors, developers)