### PR TITLE
Add architecture badges to download cards

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -149,7 +149,9 @@
                 class="download-option"
               >
                 <div class="arch">
-                  <span>x86-64 (Intel/AMD)</span>
+                  <span>x86-64</span>
+                  <span class="badge badge-intel">Intel</span>
+                  <span class="badge badge-amd">AMD</span>
                 </div>
                 <i class="fa-solid fa-download"></i>
               </a>
@@ -174,7 +176,9 @@
                 class="download-option"
               >
                 <div class="arch">
-                  <span>x86-64 (Intel/AMD)</span>
+                  <span>x86-64</span>
+                  <span class="badge badge-intel">Intel</span>
+                  <span class="badge badge-amd">AMD</span>
                 </div>
                 <i class="fa-solid fa-download"></i>
               </a>
@@ -200,7 +204,7 @@
               >
                 <div class="arch">
                   <span>ARM64</span>
-                  <span class="badge">Apple Silicon</span>
+                  <span class="badge badge-apple">Apple Silicon</span>
                 </div>
                 <i class="fa-solid fa-download"></i>
               </a>
@@ -209,7 +213,8 @@
                 class="download-option"
               >
                 <div class="arch">
-                  <span>x86-64 (Intel/AMD)</span>
+                  <span>x86-64</span>
+                  <span class="badge badge-intel">Intel</span>
                 </div>
                 <i class="fa-solid fa-download"></i>
               </a>

--- a/style.css
+++ b/style.css
@@ -1408,15 +1408,28 @@ footer {
 .download-option .arch {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
 .download-option .badge {
   font-size: 0.65rem;
   padding: 2px 6px;
-  background: var(--green);
-  color: var(--black);
+  background: var(--badge-bg, var(--green));
+  color: var(--white);
   font-weight: 700;
+}
+
+.download-option .badge.badge-apple {
+  --badge-bg: var(--green);
+}
+
+.download-option .badge.badge-intel {
+  --badge-bg: var(--blue);
+}
+
+.download-option .badge.badge-amd {
+  --badge-bg: var(--red);
 }
 
 .download-option .desc {
@@ -1434,8 +1447,8 @@ footer {
 }
 
 .download-option:hover .badge {
-  background: var(--black);
-  color: var(--green);
+  background: var(--badge-bg, var(--green));
+  color: var(--white);
 }
 
 .download-note {


### PR DESCRIPTION
Closes: #14 
<img width="1103" height="583" alt="Bildschirmfoto vom 2026-03-16 11-08-13" src="https://github.com/user-attachments/assets/8eb5628d-b4fc-4034-9f07-ebc89b596d5c" />
